### PR TITLE
Task: Auto bump Elasticsearch version

### DIFF
--- a/.github/actions/create_commit_message/action.yml
+++ b/.github/actions/create_commit_message/action.yml
@@ -1,0 +1,29 @@
+inputs:
+  elasticsearch-version:
+    description: 'Elasticsearch version'
+  lucene-version:
+    description: 'Lucene version'
+  java-version:
+    description: 'Java version'
+outputs:
+  commit-message:
+    description: 'Commit message'
+    value: ${{ steps.commit_message.outputs.message }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Create Commit Message
+      id: commit_message
+      shell: bash
+      run: |
+        message="bump Elasticsearch version to ${{ inputs.elasticsearch-version }}"
+
+        if [[ "${{ inputs.lucene-version }}" && "${{ inputs.java-version }}" ]]; then
+          message="${message} (and lucene to ${{ inputs.lucene-version }} and java to ${{ inputs.java-version }})"
+        elif [[ "${{ inputs.lucene-version }}" ]]; then
+          message="${message} (and lucene to ${{ inputs.lucene-version }})"
+        elif [[ "${{ inputs.java-version }}" ]]; then
+          message="${message} (and java to ${{ inputs.java-version }})"
+        fi
+
+        echo "message=${message}" >> $GITHUB_OUTPUT

--- a/.github/actions/update_elasticsearch/Dockerfile
+++ b/.github/actions/update_elasticsearch/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine/curl:8.1.2
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/actions/update_elasticsearch/action.yml
+++ b/.github/actions/update_elasticsearch/action.yml
@@ -1,0 +1,12 @@
+name: 'Update Elasticsearch'
+description: 'Checks if a new elasticsearch version is avaiable and change it in the repo files if so'
+outputs:
+  elasticsearch-versoin:
+    description: 'The version of Elasticsearch to update to. Blank if no new version is yet available'
+  lucene-version:
+    description: 'If the new Elasticsearch version uses a new Lucene version, it will be here. Blank otherwise'
+  java-version:
+    description: 'If the new Elasticsearch version uses a new Java version, it will be here. Blank otherwise'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/update_elasticsearch/entrypoint.sh
+++ b/.github/actions/update_elasticsearch/entrypoint.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+cd "${GITHUB_WORKSPACE}"
+
+maven_repo_url='https://repo.maven.apache.org/maven2/org/elasticsearch/elasticsearch/'
+release_notes_url='https://www.elastic.co/guide/en/elasticsearch/reference/current/'
+
+current_elasticsearch_version=$(sed -nr 's/.*<elasticsearch\.version>([0-9]+\.[0-9]+\.[0-9]+)<\/elasticsearch\.version>.*/\1/p' ./pom.xml)
+
+major=$(echo $current_elasticsearch_version | awk -F. '{print $1}')
+minor=$(echo $current_elasticsearch_version | awk -F. '{print $2}')
+patch=$(echo $current_elasticsearch_version | awk -F. '{print $3}')
+
+let next_major=$major+1
+let next_minor=$minor+1
+let next_patch=$patch+1
+
+next_major_version=${next_major}.0.0
+next_minor_version=${major}.${next_minor}.0
+next_patch_version=${major}.${minor}.${next_patch}
+
+for version_to_try in $next_patch_version $next_minor_version $next_patch_version
+do
+    version_url_in_repo="${maven_repo_url}${version_to_try}/"
+
+    echo "Checking ${version_url_in_repo} with HEAD request..."
+    http_code=$(curl -I -o /dev/null -w "%{http_code}" ${version_url_in_repo})
+
+    if [ $http_code -eq 200 ]
+    then
+        elasticsearch_version=$version_to_try
+        break
+    fi
+done
+
+if [ $elasticsearch_version ]
+then
+    echo "New elasticsearch version: ${elasticsearch_version}"
+
+    release_notes_url="${release_notes_url}release-notes-${elasticsearch_version}.html"
+
+    echo "Getting release notes from ${release_notes_url}"
+    release_notes_http=$(curl ${release_notes_url})
+
+    lucene_version=$(echo $release_notes_http | sed -nr "s/.*upgrade[a-z ]*lucene[a-z ]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/pI")
+    java_version=$(echo $release_notes_http | sed -nr "s/.*upgrade[a-z ]*JDK[a-z ]*([0-9]+).*/\1/pI")
+
+    echo "New Lucene version is ${lucene_version}"
+    echo "New Java version is ${java_version}"
+
+    # Updrage Elasticsearch version
+    sed -r -i "s/<elasticsearch\.version>[0-9]+\.[0-9]+\.[0-9]+<\/elasticsearch\.version>/<elasticsearch.version>${elasticsearch_version}<\/elasticsearch.version>/" ./pom.xml
+
+    if [ $lucene_version ]
+    then
+        sed -r -i "s/<lucene\.version>[0-9]+\.[0-9]+\.[0-9]+<\/lucene\.version>/<lucene.version>${lucene_version}<\/lucene.version>/" ./pom.xml
+    fi
+
+    if [ $java_version ]
+    then
+        echo $java_version > ./es-java-version
+    fi
+else
+    echo "No new Elasticseach version was found"
+fi
+
+echo "elasticsearch-version=${elasticsearch_version}" >> ${GITHUB_OUTPUT}
+echo "lucene-version=${lucene_version}" >> ${GITHUB_OUTPUT}
+echo "java-version=${java_version}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,32 @@
+name: Auto Updater
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 17 * * *'
+
+jobs:
+  update-elasticsearch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: update
+        id: update_es
+        uses: ./.github/actions/update_elasticsearch
+      - name: Create commit message
+        id: commit_message
+        if: steps.update_es.outputs.elasticsearch-version
+        uses: ./.github/actions/create_commit_message
+        with:
+          elasticsearch-version: ${{ steps.update_es.outputs.elasticsearch-version }}
+          lucene-version: ${{ steps.update_es.outputs.lucene-version }}
+          java-version: ${{ steps.update_es.outputs.java-version }}
+      - name: Open PR
+        if: steps.update_es.outputs.elasticsearch-version
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+          branch: releases/release-v${{ steps.update_es.outputs.elasticsearch-version }}
+          commit-message: ${{ steps.commit_message.outputs.commit-message}}
+          title: Releases v${{ steps.update_es.outputs.elasticsearch-version }}

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,29 @@
+name: Create Tag
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+      - name: Get tag name from branch name
+        id: get_tag_name
+        if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'releases/') }}
+        run: |
+          tag_name=$(echo ${{ github.event.pull_request.head.ref }} | sed -nr 's/^releases\/release-(v[0-9]{0,4}\.[0-9]{0,4}\.[0-9]{0,4}(\.[0-9]{0,4}){0,3})$/\1/p')
+          echo "tag_name=${tag_name}" >> $GITHUB_OUTPUT
+      - name: Create tag
+        if: steps.get_tag_name.outputs.tag_name
+        uses: rickstaa/action-create-tag@v1
+        with:
+          github_token: ${{ secrets.REPO_GHA_PAT }}
+          tag: ${{ steps.get_tag_name.outputs.tag_name }}


### PR DESCRIPTION
Since Elasticsearch plugins are specific to Elasticsearch version, we need to make a new release whenever a new Elasticsearch version comes out. This is tedious, and can lead to period of times when new Elasticsearch versions don't have an appropriate version of the plugin. This PR comes to solve this.

This PR adds the following:
* Once a day we check whether a new Elasticsearch version is available. If it is , we also check whether it uses new versions of Java and Lucene, and open a Release PR which bumps the Elasitcsearc version in the `pom.xml` file (and if necessary - also the Lucene version in `pom.xml` and the Java version in `es-java-version`.
* When the PR is merged - another workflow will create a release tag. The existing `run-test` workflow will run the tests on the PR's branch.

From there the existing `create-release` workflow will create a release from the new tag.