### PR TITLE
Task PHIS: downgrade Elasticsearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,6 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 	<dependencies>
-	    <dependency>
-			<groupId>org.elasticsearch</groupId>
-			<artifactId>elasticsearch</artifactId>
-			<version>${elasticsearch.version}</version>
-			<scope>compile</scope>
-	    </dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-test-framework</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 	<version>${elasticsearch.version}</version>
 	<packaging>jar</packaging>
 	<properties>
-	    <elasticsearch.version>7.3.1</elasticsearch.version>
-		<lucene.version>8.1.0</lucene.version>
+	    <elasticsearch.version>7.6.2</elasticsearch.version>
+		<lucene.version>8.4.0</lucene.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 	<version>${elasticsearch.version}</version>
 	<packaging>jar</packaging>
 	<properties>
-	    <elasticsearch.version>8.11.1</elasticsearch.version>
-		<lucene.version>9.8.0</lucene.version>
+	    <elasticsearch.version>7.3.1</elasticsearch.version>
+		<lucene.version>8.1.0</lucene.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>


### PR DESCRIPTION
Removing Elasticsearch dependency from the pom to handle the vulnerability related to using an AGPL license which we cannot use
https://rapid7.atlassian.net/browse/PHIS-3588